### PR TITLE
Renamed method argument class to aClass as class is a reserved keywor…

### DIFF
--- a/MTLManagedObjectAdapter/MTLManagedObjectAdapter.h
+++ b/MTLManagedObjectAdapter/MTLManagedObjectAdapter.h
@@ -231,7 +231,7 @@ extern const NSInteger MTLManagedObjectAdapterErrorInvalidManagedObjectMapping;
 //         nil.
 //
 // Returns a value transformer or nil if no transformation should be used.
-+ (NSValueTransformer *)transformerForModelPropertiesOfClass:(Class)class;
++ (NSValueTransformer *)transformerForModelPropertiesOfClass:(Class)aClass;
 
 // A value transformer that should be used for a properties of the given
 // primitive type.

--- a/MTLManagedObjectAdapter/MTLManagedObjectAdapter.m
+++ b/MTLManagedObjectAdapter/MTLManagedObjectAdapter.m
@@ -75,7 +75,7 @@ static SEL MTLSelectorWithKeyPattern(NSString *key, const char *suffix) {
 //
 // Returns a dictionary with the properties of modelClass that need
 // transformation as keys and the value transformers as values.
-- (NSDictionary *)valueTransformersForModelClass:(Class)class;
+- (NSDictionary *)valueTransformersForModelClass:(Class)aClass;
 
 // Initializes the receiver to serialize or deserialize a MTLModel of the given
 // class.
@@ -761,10 +761,10 @@ static SEL MTLSelectorWithKeyPattern(NSString *key, const char *suffix) {
 	return result;
 }
 
-+ (NSValueTransformer *)transformerForModelPropertiesOfClass:(Class)class {
-	NSParameterAssert(class != nil);
++ (NSValueTransformer *)transformerForModelPropertiesOfClass:(Class)aClass {
+	NSParameterAssert(aClass != nil);
 
-	SEL selector = MTLSelectorWithKeyPattern(NSStringFromClass(class), "EntityAttributeTransformer");
+	SEL selector = MTLSelectorWithKeyPattern(NSStringFromClass(aClass), "EntityAttributeTransformer");
 	if (![self respondsToSelector:selector]) return nil;
 
 	NSInvocation *invocation = [NSInvocation invocationWithMethodSignature:[self methodSignatureForSelector:selector]];


### PR DESCRIPTION
…d when compiling for Objective-C++